### PR TITLE
Fix bug when there are no components

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -57,7 +57,7 @@ class VueBrunch {
     extractCSS() {
         var that = this;
         var outPath = this.config.out || this.config.o || 'bundle.css';
-        var css = Object.keys(this.styles)
+        var css = Object.keys(this.styles || [])
             .map(function (file) {
                 return that.styles[file].replace(/(\/\*.*)stdin(.*\*\/)/g, "$1" + file + "$2")
             })


### PR DESCRIPTION
This PR fixes a subtle bug: when there are no Vue components, the `onCompile()` brunch hook is still invoked. However, in this case `this.styles` will be undefined and hence `extractCSS()` will fail.