### PR TITLE
Make styles map survive compile runs

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -14,6 +14,7 @@ class VueBrunch {
 
     constructor(config) {
         this.config = config && config.plugins && config.plugins.vue || {};
+        this.styles = Object.create(null);
     }
 
     /**
@@ -24,8 +25,6 @@ class VueBrunch {
      * @return {promise}
      */
     compile(file) {
-
-        this.styles = Object.create(null);
 
         if (this.config) {
             compiler.applyConfig(this.config);
@@ -59,7 +58,7 @@ class VueBrunch {
         var outPath = this.config.out || this.config.o || 'bundle.css';
         var css = Object.keys(this.styles || [])
             .map(function (file) {
-                return that.styles[file].replace(/(\/\*.*)stdin(.*\*\/)/g, "$1" + file + "$2")
+                return that.styles[file].replace(/(\/\*.*)stdin(.*\*\/)/g, "$1" + file + "$2");
             })
             .join('\n');
 


### PR DESCRIPTION
This PR further improves the support for the `extractCSS` option by making sure the component styles map built during compilation survives between individual runs of the brunch pipeline. This fix is necessary for making the option work correctly with `brunch watch` -- without it, only the CSS related to the components actually compiled during a pipeline run will be extracted (i.e. it really was "extract CSS of modified components" rather than "extract CSS of all components").