### PR TITLE
remove existing styles for a file before compilation, fixes #33

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -11,7 +11,9 @@ class VueBrunch {
   }
 
   compile(file) {
-
+    // clean up existing styles for this file
+    delete this.styles[file.path];
+    
     if (this.config) {
       compiler.applyConfig(this.config);
     }


### PR DESCRIPTION
Removing the existing styles for a file before compilation works to prevent the "caching" issue referenced in issue #33. I've tested this with multiple files and styles will remain from other files while those that get fully removed from other files are no longer present.